### PR TITLE
Pin aiohttp to latest version 2.2.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyupio==0.8.2
-aiohttp
+aiohttp==2.2.5
 simplejson


### PR DESCRIPTION

aiohttp is not pinned to a specific version.

I'm pinning it to the latest version **2.2.5** for now.




Happy merging! 🤖

---
*Running the bot with an API key allows it to query pyup.io's API for changelogs and insecure packages. This is highly recommended for production use. [Learn More](https://pyup.io/docs/api-key/)*
