### PR TITLE
Pin simplejson to latest version 3.11.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyupio==0.8.2
 aiohttp
-simplejson
+simplejson==3.11.1


### PR DESCRIPTION

simplejson is not pinned to a specific version.

I'm pinning it to the latest version **3.11.1** for now.




Happy merging! 🤖

---
*Running the bot with an API key allows it to query pyup.io's API for changelogs and insecure packages. This is highly recommended for production use. [Learn More](https://pyup.io/docs/api-key/)*
